### PR TITLE
FIX: Allow any number of proxies

### DIFF
--- a/httpconfig.js
+++ b/httpconfig.js
@@ -6,7 +6,7 @@ var path = require('path');
 var app = express();
 var port = parseInt(process.env.PORT, 10) || 9000;
 
-app.set('trust proxy', 1);
+app.set('trust proxy', true);
 
 app.use(compression());
 app.use('/static', express.static(path.join(__dirname, 'static')));


### PR DESCRIPTION
## Why?

I went a little far hardening things and allowed only one proxy in the connection, which kind of flies in the face of what this app is supposed to do.

## What changed?
- allowed any number of proxies