### PR TITLE
[Feature] Prettier

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+prettier --check "**/*.{js,scss,html}"

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "arrowParens": "always",
+  "singleQuote": true
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,10 @@
       },
       "devDependencies": {
         "chai": "^6.2.2",
+        "husky": "^9.1.7",
         "mocha": "^11.7.5",
         "normalize.css": "^8.0.1",
+        "prettier": "^3.8.1",
         "sass": "^1.98.0",
         "supertest": "^7.2.2"
       },
@@ -1417,6 +1419,22 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -1923,6 +1941,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
+      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/proxy-addr": {

--- a/package.json
+++ b/package.json
@@ -12,15 +12,20 @@
   },
   "devDependencies": {
     "chai": "^6.2.2",
+    "husky": "^9.1.7",
     "mocha": "^11.7.5",
     "normalize.css": "^8.0.1",
+    "prettier": "^3.8.1",
     "sass": "^1.98.0",
     "supertest": "^7.2.2"
   },
   "scripts": {
     "build": "sass static/scss/httpconfig.scss static/css/httpconfig.css --no-source-map --load-path=node_modules",
+    "format": "prettier --write \"**/*.{js,scss,html}\"",
+    "format:check": "prettier --check \"**/*.{js,scss,html}\"",
     "start": "node httpconfig.js",
-    "test": "mocha"
+    "test": "mocha",
+    "prepare": "husky"
   },
   "private": true,
   "repository": {

--- a/static/html/httpconfig.html
+++ b/static/html/httpconfig.html
@@ -1,32 +1,48 @@
-<!DOCTYPE html>
+<!doctype html>
 <!--[if lt IE 7]> <html class="no-js lt-ie10 lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
 <!--[if IE 7]>    <html class="no-js lt-ie10 lt-ie9 lt-ie8"> <![endif]-->
 <!--[if IE 8]>    <html class="no-js lt-ie10 lt-ie9"> <![endif]-->
 <!--[if IE 9]>    <html class="no-js lt-ie10"> <![endif]-->
-<!--[if gt IE 9]><!--> <html class="no-js"> <!--<![endif]-->
-<head>
+<!--[if gt IE 9]><!-->
+<html class="no-js">
+  <!--<![endif]-->
+  <head>
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>httpconfig</title>
     <link rel="stylesheet" href="static/css/httpconfig.css" />
-</head>
-<body>
+  </head>
+  <body>
     <header>
-        <h1>httpconfig</h1>
-        <hr />
+      <h1>httpconfig</h1>
+      <hr />
     </header>
     <footer>
-        <hr />
-        <p>&copy;2013 <a href="http://www.gregorygreen.info">Gregory Green</a>.</p>
+      <hr />
+      <p>
+        &copy;2013 <a href="http://www.gregorygreen.info">Gregory Green</a>.
+      </p>
     </footer>
-    <script data-dojo-config="async: 1" src="//ajax.googleapis.com/ajax/libs/dojo/1.9.2/dojo/dojo.js"></script>
+    <script
+      data-dojo-config="async: 1"
+      src="//ajax.googleapis.com/ajax/libs/dojo/1.9.2/dojo/dojo.js"
+    ></script>
     <script src="static/js/httpconfig.js"></script>
     <script type="text/javascript">
-    var _gaq=[['_setAccount','UA-37683371-1'],['_setDomainName', 'gregorygreen.info'],['_trackPageview']];
-    (function(d,t){var g=d.createElement(t),s=d.getElementsByTagName(t)[0];
-    g.src=('https:'==location.protocol?'//ssl':'//www')+'.google-analytics.com/ga.js';
-    s.parentNode.insertBefore(g,s)}(document,'script'));
+      var _gaq = [
+        ['_setAccount', 'UA-37683371-1'],
+        ['_setDomainName', 'gregorygreen.info'],
+        ['_trackPageview'],
+      ];
+      (function (d, t) {
+        var g = d.createElement(t),
+          s = d.getElementsByTagName(t)[0];
+        g.src =
+          ('https:' == location.protocol ? '//ssl' : '//www') +
+          '.google-analytics.com/ga.js';
+        s.parentNode.insertBefore(g, s);
+      })(document, 'script');
     </script>
-</body>
+  </body>
 </html>

--- a/static/js/httpconfig.js
+++ b/static/js/httpconfig.js
@@ -1,37 +1,51 @@
-require(['dojo/request', 'dojo/dom-construct', 'dojo/query', 'dojo/domReady!'], function(request, domConstruct, query) {
+require([
+  'dojo/request',
+  'dojo/dom-construct',
+  'dojo/query',
+  'dojo/domReady!',
+], function (request, domConstruct, query) {
+  function handleRequestSuccess(res) {
+    var container = domConstruct.create('table', { className: 'container' }),
+      key;
 
-    function handleRequestSuccess(res) {
-        var container = domConstruct.create('table', { className: 'container' }),
-            key;
-
-        for (key in res) {
-            if (res.hasOwnProperty(key)) {
-                domConstruct.create('tr', {
-                    className: 'result-' + key,
-                    innerHTML: '<td class="property">' + res[key].displayName + '</td>' +
-                               '<td class="value">' + (res[key].value || '') + '</td>'
-                }, container);
-            }
-        }
-
-        // if (navigator.geolocation) {
-        //     navigator.geolocation.getCurrentPosition(function(position) {
-        //         domConstruct.create('tr', {
-        //             className: 'result-latitude',
-        //             innerHTML: '<td class="property">Latitude</td>' +
-        //                        '<td class="value">' + position.coords.latitude + '</td>'
-        //         }, container);
-        //         domConstruct.create('tr', {
-        //             className: 'result-longitude',
-        //             innerHTML: '<td class="property">Longitude</td>' +
-        //                        '<td class="value">' + position.coords.longitude + '</td>'
-        //         }, container);
-        //     }, function() {}, { maximumAge: 60000 });
-        // }
-
-        domConstruct.place(container, query('header')[0], 'after');
+    for (key in res) {
+      if (res.hasOwnProperty(key)) {
+        domConstruct.create(
+          'tr',
+          {
+            className: 'result-' + key,
+            innerHTML:
+              '<td class="property">' +
+              res[key].displayName +
+              '</td>' +
+              '<td class="value">' +
+              (res[key].value || '') +
+              '</td>',
+          },
+          container,
+        );
+      }
     }
 
-    request.get('/api/httpconfig', { handleAs: 'json' }).then(handleRequestSuccess);
+    // if (navigator.geolocation) {
+    //     navigator.geolocation.getCurrentPosition(function(position) {
+    //         domConstruct.create('tr', {
+    //             className: 'result-latitude',
+    //             innerHTML: '<td class="property">Latitude</td>' +
+    //                        '<td class="value">' + position.coords.latitude + '</td>'
+    //         }, container);
+    //         domConstruct.create('tr', {
+    //             className: 'result-longitude',
+    //             innerHTML: '<td class="property">Longitude</td>' +
+    //                        '<td class="value">' + position.coords.longitude + '</td>'
+    //         }, container);
+    //     }, function() {}, { maximumAge: 60000 });
+    // }
 
+    domConstruct.place(container, query('header')[0], 'after');
+  }
+
+  request
+    .get('/api/httpconfig', { handleAs: 'json' })
+    .then(handleRequestSuccess);
 });

--- a/static/scss/httpconfig.scss
+++ b/static/scss/httpconfig.scss
@@ -1,22 +1,22 @@
 @use 'normalize.css/normalize';
 
 @mixin font-size($sizeValue, $heightValue) {
-    font-size: ($sizeValue * 10) + px;
-    line-height: $heightValue;
+  font-size: ($sizeValue * 10) + px;
+  line-height: $heightValue;
 }
 
 html {
-    font-family: sans-serif;
-    font-size: 62.5%;
-    -webkit-font-smoothing: antialiased;
+  font-family: sans-serif;
+  font-size: 62.5%;
+  -webkit-font-smoothing: antialiased;
 }
 
 body {
-    color: #333333;
-    @include font-size(1.6, 1.5);
-    margin: 0 auto;
-    max-width: 700px;
-    padding: 0 20px;
+  color: #333333;
+  @include font-size(1.6, 1.5);
+  margin: 0 auto;
+  max-width: 700px;
+  padding: 0 20px;
 }
 
 a {
@@ -30,80 +30,80 @@ a {
 }
 
 h1 {
-    color: #999;
-    @include font-size(3.2, 1.5);
-    margin: 0;
-    padding-top: 24px;
+  color: #999;
+  @include font-size(3.2, 1.5);
+  margin: 0;
+  padding-top: 24px;
 }
 
 hr {
-    border: 0;
-    border-top: 1px solid #eee;
-    border-bottom: 1px solid #fff;
-    margin: 24px 0;
+  border: 0;
+  border-top: 1px solid #eee;
+  border-bottom: 1px solid #fff;
+  margin: 24px 0;
 
-    header & {
-        margin-bottom: 48px;
-    }
+  header & {
+    margin-bottom: 48px;
+  }
 
-    footer & {
-        margin-top: 48px;
-    }
+  footer & {
+    margin-top: 48px;
+  }
 }
 
 .container {
-    border: 1px solid #ddd;
-    border-collapse: separate;
-    border-spacing: 0;
-    border-radius: 4px;
-    margin: 0 auto 20px;
-    width: 90%;
+  border: 1px solid #ddd;
+  border-collapse: separate;
+  border-spacing: 0;
+  border-radius: 4px;
+  margin: 0 auto 20px;
+  width: 90%;
 
-    td {
-        border-top: 1px solid #ddd;
-        line-height: 20px;
-        padding: 8px;
-        text-align: left;
-        vertical-align: middle;
+  td {
+    border-top: 1px solid #ddd;
+    line-height: 20px;
+    padding: 8px;
+    text-align: left;
+    vertical-align: middle;
 
-        &:first-child {
-            border-right: 1px solid #ddd;
-        }
+    &:first-child {
+      border-right: 1px solid #ddd;
     }
+  }
 
-    tr {
+  tr {
+    &:first-child {
+      td {
+        border-top: 0;
+
         &:first-child {
-            td {
-                border-top: 0;
-
-                &:first-child {
-                    border-top-left-radius: 4px;
-                }
-
-                &:last-child {
-                    border-top-right-radius: 4px;
-                }
-            }
+          border-top-left-radius: 4px;
         }
 
         &:last-child {
-            td {
-                &:first-child {
-                    border-bottom-left-radius: 4px;
-                }
-
-                &:last-child {
-                    border-bottom-right-radius: 4px;
-                }
-            }
+          border-top-right-radius: 4px;
         }
-
-        &:nth-child(odd) {
-            background-color: #f9f9f9;
-        }
+      }
     }
+
+    &:last-child {
+      td {
+        &:first-child {
+          border-bottom-left-radius: 4px;
+        }
+
+        &:last-child {
+          border-bottom-right-radius: 4px;
+        }
+      }
+    }
+
+    &:nth-child(odd) {
+      background-color: #f9f9f9;
+    }
+  }
 }
 
 footer {
-    text-align: center;
+  text-align: center;
 }

--- a/test/httpconfig.test.js
+++ b/test/httpconfig.test.js
@@ -21,7 +21,16 @@ describe('GET /api/httpconfig', function () {
 
   it('response contains all expected fields', async function () {
     const res = await request(app).get('/api/httpconfig');
-    const fields = ['ip', 'hostname', 'ua', 'language', 'connection', 'encoding', 'mimeType', 'charset'];
+    const fields = [
+      'ip',
+      'hostname',
+      'ua',
+      'language',
+      'connection',
+      'encoding',
+      'mimeType',
+      'charset',
+    ];
 
     for (const field of fields) {
       expect(res.body).to.have.property(field);


### PR DESCRIPTION
Adds Prettier to standardize code style across the project and enforces it automatically before every commit via Husky.

## What changed?

- Prettier (prettier, .prettierrc) — configured with singleQuote: true and arrowParens: always, targeting .js, .scss, and .html files
- Husky (.husky/pre-commit) — runs prettier --check before every commit, blocking unformatted code from being committed
- New scripts — npm run format (auto-fix) and npm run format:check (check only)
- Formatted files — static/js/httpconfig.js, static/scss/httpconfig.scss, static/html/httpconfig.html, and test/httpconfig.test.js reformatted to match config